### PR TITLE
Feat/types

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,17 @@ const isMoreThanTen = (a: Nullish<number>) => {
 
 #### Object generics
 
-- `DeepRequired`
-- `DeepNullish`
-- `DeepNonNullable`
-- `DeepNonOptional`
-- `DeepNonNullish`
+- `KeyOf<TObject, TRestriction>`
+- `DeepKeyOf<TObject, TRestriction>`
+- `DeepRequired<T>`
+- `DeepNullish<T>`
+- `DeepNonNullish<T>`
+- `DeepNullable<T>`
+- `DeepNonNullable<T>`
+- `DeepOptional<T>`
+- `DeepNonOptional<T>`
+- `DeepPickLax<T, TKey>`
+- `DeepPick<TObject, TKey>`
 
 ### Utility functions
 
@@ -97,6 +103,17 @@ const isMoreThanTen = (a: Nullish<number>) => {
 - `isNull()`
 - `isUndefined()`
 - `isNullish()`
+
+#### Object functions
+
+- `objectKeys()`
+- `objectValues()`
+- `objectEntries()`
+- `objectFromEntries()`
+- `transformObject()`
+
+#### Array functions
+- `arrayFilter()`
 
 #### Logger
 

--- a/src/functions/object.functions.ts
+++ b/src/functions/object.functions.ts
@@ -14,7 +14,10 @@ export const transformObject = <
   TTransformedItem = TObj[keyof TObj & string]
 >(
   object: TObj,
-  itemTransformer: (item: TObj[keyof TObj & string]) => TTransformedItem,
+  itemTransformer: (
+    item: TObj[keyof TObj & string],
+    key: keyof TObj & string
+  ) => TTransformedItem,
   keyTransformer?: (key: keyof TObj & string) => TTransformedKey
 ): typeof keyTransformer extends undefined
   ? {
@@ -27,12 +30,15 @@ export const transformObject = <
     return objectFromEntries(
       objectEntries(object).map(([key, value]) => [
         keyTransformer(key),
-        itemTransformer(value),
+        itemTransformer(value, key),
       ])
     );
   }
   return objectFromEntries(
-    objectEntries(object).map(([key, value]) => [key, itemTransformer(value)])
+    objectEntries(object).map(([key, value]) => [
+      key,
+      itemTransformer(value, key),
+    ])
   );
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export * from "./types";
+export type * from "./types";
 export * from "./functions";
 export * from "./utils";

--- a/src/tests/log.test.ts
+++ b/src/tests/log.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test";
-import { isObject, objectKeys, transformObject } from "../functions";
+import { describe, it, expect, mock } from "bun:test";
+import { isObject, objectKeys } from "../functions";
 import { Logger, LoggerConfig } from "../utils";
 
 const methodNames = ["log", "info", "warn", "error", "debug"] as const;

--- a/src/types/global/global.types.ts
+++ b/src/types/global/global.types.ts
@@ -84,33 +84,3 @@ export type NonNullish<T> = NonNullable<NonOptional<T>>;
 export type Primitives = string | number | boolean | object;
 
 export type NullishPrimitives = Nullish<Primitives>;
-
-export type DeepRequired<T> = T extends object
-  ? {
-      [TKey in keyof T]-?: T[TKey];
-    }
-  : T;
-
-export type DeepNullish<T> = T extends object
-  ? {
-      [TKey in keyof T]: DeepNullish<T[TKey]>;
-    }
-  : Nullish<T>;
-
-export type DeepNonNullable<T> = T extends object
-  ? {
-      [TKey in keyof T]: DeepNonNullable<T[TKey]>;
-    }
-  : NonNullable<T>;
-
-export type DeepNonOptional<T> = T extends object
-  ? {
-      [TKey in keyof T]: DeepNonOptional<T[TKey]>;
-    }
-  : NonOptional<T>;
-
-export type DeepNonNullish<T> = T extends object
-  ? DeepRequired<{
-      [TKey in keyof T]: DeepNonNullish<T[TKey]>;
-    }>
-  : NonNullish<T>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,4 @@
-export * from "./function";
-export * from "./global";
+export type * from "./function";
+export type * from "./global";
+export type * from "./union";
+export type * from "./object";

--- a/src/types/object/index.ts
+++ b/src/types/object/index.ts
@@ -1,0 +1,3 @@
+export type * from "./map.types";
+export type * from "./object.types";
+export type * from "./keys.types";

--- a/src/types/object/keys.types.ts
+++ b/src/types/object/keys.types.ts
@@ -1,0 +1,48 @@
+import type { Primitives } from "..";
+
+/**
+ * Extracts any top-level key of an object according to a key restriction
+ *
+ * @remarks Returns never if T is not an object
+ *
+ * @template T - The object
+ * @template {Primitives} [TRestriction = string] - The key restriction
+ */
+export type KeyOf<
+  TObject,
+  TRestriction extends Primitives = string
+> = keyof TObject & TRestriction;
+
+/**
+ * Extracts any top-level and/or deep key of an object
+ *
+ * @remarks Returns never if T is not an object
+ *
+ * @template T - The object
+ * @template {Primitives} [TKeyRestriction = string | number] - The key restriction
+ */
+export type DeepKeyOf<
+  TObject,
+  TKeyRestriction extends Primitives = string | number
+> = TObject extends object
+  ? {
+      [K in KeyOf<TObject, TKeyRestriction>]: TObject[K] extends object
+        ? `${K}.${DeepKeyOf<TObject[K]>}` | K
+        : K;
+    }[KeyOf<TObject, TKeyRestriction>]
+  : never;
+
+/**
+ * An object that must contain at least one or more keys and values in TChoices
+ *
+ * @template {Record<string, unknown>} TChoices - The object's values
+ * @template {keyof TChoices} TKeys - The object's keys
+ */
+export type RequireAtLeastOne<
+  TChoices extends Record<string, unknown>,
+  TKeys extends keyof TChoices = keyof TChoices
+> = Pick<TChoices, Exclude<keyof TChoices, TKeys>> &
+  {
+    [K in TKeys]-?: Required<Pick<TChoices, K>> &
+      Partial<Pick<TChoices, Exclude<TKeys, K>>>;
+  }[TKeys];

--- a/src/types/object/map.types.ts
+++ b/src/types/object/map.types.ts
@@ -1,0 +1,11 @@
+/**
+ * An object that must contain all keys in TKeys,
+ * where all keys in TKeys must match TValue's types
+ *
+ * @template {string} TKeys - The object's keys. A string union
+ * @template {unknown} TValues - The object's values for every key in {@link TKeys}.
+ *
+ */
+export type ValueMap<TKeys extends string, TValue> = {
+  [TKey in TKeys]: TValue;
+};

--- a/src/types/object/object.types.ts
+++ b/src/types/object/object.types.ts
@@ -88,6 +88,21 @@ export type DeepPickLax<
  *
  * @template {object} TObject - The object
  * @template {DeepKeyOf<TObject>} TKey - The key
+ *
+ * @example
+ * type MyObject = {
+ *   foo: {
+ *     bar: {
+ *       baz: number
+ *     }
+ *     foo: {
+ *       foobar: string
+ *     }
+ *   }
+ * }
+ *
+ * type MyPick = DeepPick<MyObject, 'foo.bar.baz'> // { foo : { bar: { baz: number } } }
+ *
  */
 export type DeepPick<
   TObject extends object,

--- a/src/types/object/object.types.ts
+++ b/src/types/object/object.types.ts
@@ -10,13 +10,13 @@ import type { DeepKeyOf } from "./keys.types";
 
 export type DeepRequired<T> = T extends object
   ? {
-      [TKey in keyof T]-?: T[TKey];
+      [TKey in keyof T]-?: DeepRequired<T[TKey]>;
     }
   : T;
 
 export type DeepPartial<T> = T extends object
   ? {
-      [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+      [P in keyof T]?: DeepPartial<T[P]>;
     }
   : T;
 

--- a/src/types/object/object.types.ts
+++ b/src/types/object/object.types.ts
@@ -1,5 +1,11 @@
-import type { UnionToIntersection } from "..";
-import type { Nullish, NonOptional, NonNullish } from "../global/global.types";
+import type {
+  UnionToIntersection,
+  Nullish,
+  NonOptional,
+  NonNullish,
+  Nullable,
+  Optional,
+} from "..";
 import type { DeepKeyOf } from "./keys.types";
 
 export type DeepRequired<T> = T extends object
@@ -20,23 +26,35 @@ export type DeepNullish<T> = T extends object
     }
   : Nullish<T>;
 
+export type DeepNonNullish<T> = T extends object
+  ? DeepRequired<{
+      [TKey in keyof T]: DeepNonNullish<T[TKey]>;
+    }>
+  : NonNullish<T>;
+
+export type DeepNullable<T> = T extends object
+  ? {
+      [TKey in keyof T]: DeepNullable<T[TKey]>;
+    }
+  : Nullable<T>;
+
 export type DeepNonNullable<T> = T extends object
   ? {
       [TKey in keyof T]: DeepNonNullable<T[TKey]>;
     }
   : NonNullable<T>;
 
+export type DeepOptional<T> = T extends object
+  ? {
+      [TKey in keyof T]: DeepOptional<T[TKey]>;
+    }
+  : Optional<T>;
+
 export type DeepNonOptional<T> = T extends object
   ? {
       [TKey in keyof T]: DeepNonOptional<T[TKey]>;
     }
   : NonOptional<T>;
-
-export type DeepNonNullish<T> = T extends object
-  ? DeepRequired<{
-      [TKey in keyof T]: DeepNonNullish<T[TKey]>;
-    }>
-  : NonNullish<T>;
 
 /**
  * Picks a deep slice of an object

--- a/src/types/object/object.types.ts
+++ b/src/types/object/object.types.ts
@@ -1,0 +1,77 @@
+import type { UnionToIntersection } from "..";
+import type { Nullish, NonOptional, NonNullish } from "../global/global.types";
+import type { DeepKeyOf } from "./keys.types";
+
+export type DeepRequired<T> = T extends object
+  ? {
+      [TKey in keyof T]-?: T[TKey];
+    }
+  : T;
+
+export type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+    }
+  : T;
+
+export type DeepNullish<T> = T extends object
+  ? {
+      [TKey in keyof T]: DeepNullish<T[TKey]>;
+    }
+  : Nullish<T>;
+
+export type DeepNonNullable<T> = T extends object
+  ? {
+      [TKey in keyof T]: DeepNonNullable<T[TKey]>;
+    }
+  : NonNullable<T>;
+
+export type DeepNonOptional<T> = T extends object
+  ? {
+      [TKey in keyof T]: DeepNonOptional<T[TKey]>;
+    }
+  : NonOptional<T>;
+
+export type DeepNonNullish<T> = T extends object
+  ? DeepRequired<{
+      [TKey in keyof T]: DeepNonNullish<T[TKey]>;
+    }>
+  : NonNullish<T>;
+
+/**
+ * Picks a deep slice of an object
+ *
+ * @remarks Does not have autocomplete. use {@link DeepPick}
+ *
+ * @template TObject - The object
+ * @template {string | number} TKey - The key
+ */
+export type DeepPickLax<
+  TObject,
+  TKey extends string | number
+> = UnionToIntersection<
+  TObject extends object
+    ? TKey extends `${infer THead}.${infer TTail}`
+      ? {
+          [P in THead & keyof TObject]: TTail extends DeepKeyOf<TObject[P]>
+            ? DeepPickLax<TObject[P], TTail>
+            : never;
+        }
+      : TKey extends keyof TObject
+      ? Pick<TObject, TKey>
+      : never
+    : TObject
+>;
+
+/**
+ * Superset of {@link DeepPickLax} with stricter TKey type argument
+ *
+ * @remarks Use this instead of {@link DeepPickLax}
+ *
+ * @template {object} TObject - The object
+ * @template {DeepKeyOf<TObject>} TKey - The key
+ */
+export type DeepPick<
+  TObject extends object,
+  TKey extends DeepKeyOf<TObject>
+> = DeepPickLax<TObject, TKey>;

--- a/src/types/union/enum.types.ts
+++ b/src/types/union/enum.types.ts
@@ -1,0 +1,23 @@
+/**
+ * Extracts the values contained in a string array as union type.
+ *
+ * @example
+ * const myEnumValues = ["a", "b", "c"] as const;
+ * type MyEnum = Enum<typeof myEnumValues>;
+ */
+export type Enum<T extends string[] | readonly string[]> = T[number];
+
+/**
+ * Takes a string enum or a string array and extends it with another enum.
+ *
+ * @template {string | string[] | readonly string[]} TEnum - The base string enum or string array
+ * @template {string | string[] | readonly string[]} TExtension - The extension string enum or string array
+ */
+export type EnumExtension<
+  TEnum extends string | string[] | readonly string[],
+  TExtension extends string | string[] | readonly string[]
+> =
+  | (TEnum extends string[] | readonly string[] ? Enum<TEnum> : TEnum)
+  | (TExtension extends string[] | readonly string[]
+      ? Enum<TExtension>
+      : TExtension);

--- a/src/types/union/index.ts
+++ b/src/types/union/index.ts
@@ -1,0 +1,2 @@
+export type * from "./union.types";
+export type * from "./enum.types";

--- a/src/types/union/union.types.ts
+++ b/src/types/union/union.types.ts
@@ -1,0 +1,22 @@
+/**
+ * Extracts the type of the value in TUnion that matches TSelection
+ *
+ * @remarks Not really needed, basically acts as a safeguard when using only a subset of an existing union
+ *
+ * @template TUnion - Base Union type
+ * @template TSelection - Subset of TUnion
+ */
+export type Extract<TUnion, TSelection> = TSelection extends TUnion
+  ? TSelection
+  : never;
+
+/**
+ * Converts a union type to an intersection type
+ *
+ * @template U - Union type
+ */
+export type UnionToIntersection<U> = (
+  U extends unknown ? (k: U) => void : never
+) extends (k: infer I) => void
+  ? I
+  : never;


### PR DESCRIPTION
### Features
- pass item key to `transformObject`'s `itemTransformer` callback

### Types
- Object types
  - move object related types from `global.types.ts` to own `object.types.ts` file (`DeepRequired`, `DeepNullish`, `DeepNonNullable`, `DeepNonOptional`, `DeepNonNullish`)
  - Deep object types (`DeepNullable`, `DeepOptional`, `DeepPick`, `DeepPickLax`)
  - Key-related types (`KeyOf`, `DeepKeyOf`, `RequireAtLeaseOne`)
  - Mapping types (`ValueMap`)
- Union types
  - Enum types (`Enum`, `EnumExtension`)
  - Union logic types (`Extract`, `UnionToIntersection`)